### PR TITLE
Only use nameof for C# 6 or higher

### DIFF
--- a/src/NullParameterCheckRefactoring/NullParameterCheckRefactoringProvider.cs
+++ b/src/NullParameterCheckRefactoring/NullParameterCheckRefactoringProvider.cs
@@ -101,7 +101,7 @@ namespace NullParameterCheckRefactoring
             {
                 parameterNameExpression = SyntaxFactory.NameOfExpression(
                     "nameof",
-                    SyntaxFactory.ParseTypeName(parameter.Identifier.Text));
+                    SyntaxFactory.ParseExpression(parameter.Identifier.Text));
             }
             else
             {


### PR DESCRIPTION
Fixes #1

The language version is exposed through the `CSharpParseOptions.LanguageVersion` property, which can be set in the project file using the `<LangVersion>` property.

Also fixes a misuse of `ParseTypeName` that should have been `ParseExpression`.
