### PR TITLE
Visual Basic implementation cleanup

### DIFF
--- a/src/NullParameterCheckRefactoring.VB/CodeRefactoringProvider.vb
+++ b/src/NullParameterCheckRefactoring.VB/CodeRefactoringProvider.vb
@@ -63,7 +63,7 @@ Friend Class NullCheck_CodeRefactoringCodeRefactoringProvider
     Dim if_ = SyntaxFactory.SingleLineIfStatement(
                 _IsExpr_,
                 New SyntaxList(Of StatementSyntax)().Add(throwExpr),
-                Nothing).WithAdditionalAnnotations(Formatting.Formatter.Annotation)
+                Nothing).WithAdditionalAnnotations(Formatting.Formatter.Annotation, Simplification.Simplifier.Annotation)
 
     Dim newStatements = method.Statements.Insert(0, if_)
     Dim newBlock = method.WithStatements(newStatements)


### PR DESCRIPTION
Currently this pull request does not change any behavior.
- Simplify code for creating new syntax trees
- Add the `Simplifier.Annotation` annotation, which is supposed to fix #18 but currently does not (appears to be a bug in Roslyn, which is now filed as [work item 399](https://roslyn.codeplex.com/workitem/399))
