### PR TITLE
Use ValueText instead of Text for the generated string literal in C# 5

### DIFF
--- a/src/NullParameterCheckRefactoring.CSharp/NullParameterCheckRefactoringProvider.cs
+++ b/src/NullParameterCheckRefactoring.CSharp/NullParameterCheckRefactoringProvider.cs
@@ -116,7 +116,7 @@ namespace NullParameterCheckRefactoring
             {
                 parameterNameExpression = SyntaxFactory.LiteralExpression(
                     SyntaxKind.StringLiteralExpression,
-                    SyntaxFactory.Literal(parameter.Identifier.Text));
+                    SyntaxFactory.Literal(parameter.Identifier.ValueText));
             }
 
             ObjectCreationExpressionSyntax objectCreationExpression = SyntaxFactory.ObjectCreationExpression(


### PR DESCRIPTION
Fixes #25
